### PR TITLE
Fixes autodiscover max redirection exception for one url

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -605,7 +605,7 @@ public class AutodiscoverService extends ExchangeServiceBase
                               settings
                                   .getRedirectTarget()));
 
-              urls.add(currentUrlIndex, new URI(
+              urls.set(currentUrlIndex, new URI(
                   settings.getRedirectTarget()));
 
               break;

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -553,6 +553,7 @@ public class AutodiscoverService extends ExchangeServiceBase
     int scpUrlCount;
     OutParam<Integer> outParamInt = new OutParam<Integer>();
     List<URI> urls = this.getAutodiscoverServiceUrls(domainName, outParamInt);
+    List<URI> origUrls = new ArrayList<URI>(urls);
     scpUrlCount = outParamInt.getParam();
     if (urls.size() == 0) {
       throw new ServiceValidationException(
@@ -574,6 +575,9 @@ public class AutodiscoverService extends ExchangeServiceBase
 
     do {
       URI autodiscoverUrl = urls.get(currentUrlIndex);
+      if (origUrls.contains(autodiscoverUrl)) {
+        currentHop.setParam(1);
+      }
       boolean isScpUrl = currentUrlIndex < scpUrlCount;
 
       try {


### PR DESCRIPTION
When the first to-be-discovered url returning a response type of redirection, it will increase the currentHop until it reaches `AutodiscoverMaxRedirections`, then if next to-be-discovered url (not from redirection) has a redirection url, the new redirection url will not get through the system since the current hop has reached max, this fix will make a copy from the original urls from `getAutodiscoverServiceUrls` and check if the new to-be-discovered url is from this origin, then it will reset current hop if so. 
Aslo, changed the `urls.add` method to `urls.set` for not increasing the urls' list size with a lot of dummy urls ( e.g. if detecting a new redirect url, it will add the redirect target to current index and continue with the current index, however the old url will be shifted to next index so when the next index of url being discovered, it will do the same loop until hitting the `AutodiscoverMaxRedirections`), this will decrease the number of requests that fetching unnecessary urls and increase performance.
